### PR TITLE
Enable SSL requests (insecure_ssl option included)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.ini

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -1,0 +1,7 @@
+[dirs]
+root_dir = "<Root Directory full path>"
+
+[auth]
+username = "<LDAP Username>"
+password = "<LDAP Password>"
+url = "http://moodle.iitb.ac.in/login/index.php"

--- a/moodle.py
+++ b/moodle.py
@@ -4,6 +4,7 @@ import urllib
 import os
 import os.path
 import re
+import ssl
 
 from ConfigParser import ConfigParser
 
@@ -18,9 +19,15 @@ username = conf.get("auth", "username")
 password = conf.get("auth", "password")
 authentication_url = conf.get("auth", "url")
 
+# Optional: ignore incorrect SSL certificates
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
 # Store the cookies and create an opener that will hold them
 cj = cookielib.CookieJar()
-opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
+#opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
+opener = urllib2.build_opener(urllib2.HTTPSHandler(context=ctx), urllib2.HTTPCookieProcessor(cj))
 
 # Add our headers
 opener.addheaders = [('User-agent', 'Moodle-Crawler')]

--- a/moodle.py
+++ b/moodle.py
@@ -54,11 +54,12 @@ response = urllib2.urlopen(req)
 contents = response.read()
 
 # Verify the contents
-if "My courses" not in contents:
+if "Mis cursos" not in contents:
+    #print contents
     print "Cannot connect to moodle"
     exit(1)
 
-courses = contents.split("<h2>My courses</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
+courses = contents.split("<h2>Mis cursos</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
 
 regex = re.compile('<h3 class="coursename">(.*?)</h3>')
 course_list = regex.findall(courses)
@@ -87,7 +88,7 @@ for course in courses:
         # Checking only resources... Ignoring forum and folders, etc
         if "resource" in href:
             cj1 = cookielib.CookieJar()
-            opener1 = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj1))
+            opener1 = urllib2.build_opener(urllib2.HTTPSHandler(context=ctx),urllib2.HTTPCookieProcessor(cj1))
 
             # Add our headers
             opener1.addheaders = [('User-agent', 'Moodle-Crawler')]

--- a/moodle.py
+++ b/moodle.py
@@ -19,6 +19,7 @@ username = conf.get("auth", "username")
 password = conf.get("auth", "password")
 authentication_url = conf.get("auth", "url")
 insecure_ssl = conf.has_option("options", "insecure_ssl") and conf.get("options", "insecure_ssl") or "disabled";
+my_courses = conf.has_option("options", "my_courses") and conf.get("options", "my_courses") or "My courses";
 
 ctx = ssl.create_default_context()
 # Ignore incorrect SSL certificates
@@ -57,11 +58,11 @@ response = urllib2.urlopen(req)
 contents = response.read()
 
 # Verify the contents
-if "My courses" not in contents:
+if my_courses not in contents:
     print "Cannot connect to moodle"
     exit(1)
 
-courses = contents.split("<h2>My courses</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
+courses = contents.split("<h2>" + my_courses + "</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
 
 regex = re.compile('<h3 class="coursename">(.*?)</h3>')
 course_list = regex.findall(courses)

--- a/moodle.py
+++ b/moodle.py
@@ -57,12 +57,11 @@ response = urllib2.urlopen(req)
 contents = response.read()
 
 # Verify the contents
-if "Mis cursos" not in contents:
-    #print contents
+if "My courses" not in contents:
     print "Cannot connect to moodle"
     exit(1)
 
-courses = contents.split("<h2>Mis cursos</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
+courses = contents.split("<h2>My courses</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
 
 regex = re.compile('<h3 class="coursename">(.*?)</h3>')
 course_list = regex.findall(courses)

--- a/moodle.py
+++ b/moodle.py
@@ -29,7 +29,6 @@ if insecure_ssl == "enabled":
 
 # Store the cookies and create an opener that will hold them
 cj = cookielib.CookieJar()
-#opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
 opener = urllib2.build_opener(urllib2.HTTPSHandler(context=ctx), urllib2.HTTPCookieProcessor(cj))
 
 # Add our headers

--- a/moodle.py
+++ b/moodle.py
@@ -18,11 +18,14 @@ root_directory = conf.get("dirs", "root_dir")
 username = conf.get("auth", "username")
 password = conf.get("auth", "password")
 authentication_url = conf.get("auth", "url")
+insecure_ssl = conf.has_option("options", "insecure_ssl") and conf.get("options", "insecure_ssl") or "disabled";
 
-# Optional: ignore incorrect SSL certificates
 ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+# Ignore incorrect SSL certificates
+if insecure_ssl == "enabled":
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    print "Insecure SSL mode enabled: we will not check the certificates"
 
 # Store the cookies and create an opener that will hold them
 cj = cookielib.CookieJar()

--- a/moodle.py
+++ b/moodle.py
@@ -19,7 +19,6 @@ username = conf.get("auth", "username")
 password = conf.get("auth", "password")
 authentication_url = conf.get("auth", "url")
 insecure_ssl = conf.has_option("options", "insecure_ssl") and conf.get("options", "insecure_ssl") or "disabled";
-my_courses = conf.has_option("options", "my_courses") and conf.get("options", "my_courses") or "My courses";
 
 ctx = ssl.create_default_context()
 # Ignore incorrect SSL certificates
@@ -58,11 +57,11 @@ response = urllib2.urlopen(req)
 contents = response.read()
 
 # Verify the contents
-if my_courses not in contents:
+if "My courses" not in contents:
     print "Cannot connect to moodle"
     exit(1)
 
-courses = contents.split("<h2>" + my_courses + "</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
+courses = contents.split("<h2>My courses</h2>")[1].split('<aside id="block-region-side-pre" ')[0]
 
 regex = re.compile('<h3 class="coursename">(.*?)</h3>')
 course_list = regex.findall(courses)


### PR DESCRIPTION
The following PR enables HTTPS requests, including those without a valid SSL certificate.

To ignore invalid SSL certificates, I add this configuration to my `config.ini` file:

```
[options]
insecure_ssl = enabled
```

By default, **insecure_ssl** value is `disabled`