### PR TITLE
fix parsing of url on mac or with special character

### DIFF
--- a/moodle.py
+++ b/moodle.py
@@ -16,7 +16,7 @@ conf.read(os.path.join(project_dir, 'config.ini'))
 root_directory = conf.get("dirs", "root_dir")
 username = conf.get("auth", "username")
 password = conf.get("auth", "password")
-authentication_url = conf.get("auth", "url")
+authentication_url = conf.get("auth", "url").strip('\'"')
 
 # Store the cookies and create an opener that will hold them
 cj = cookielib.CookieJar()


### PR DESCRIPTION
This might be an issue only happen with certain locale or with some special character that the url is not parsed correctly by the urllib2. A simple fix based on 
[http://stackoverflow.com/questions/26559709/unknown-url-type-error-in-urllib2](url)